### PR TITLE
added a scheduler override that ignores the schedule

### DIFF
--- a/myscheduler/core.py
+++ b/myscheduler/core.py
@@ -55,7 +55,8 @@ DEFAULT_PREFS = {
     "low_active_up": -1,
     "button_state": [[0] * 7 for dummy in xrange(24)],
     "force_use_individual" : True,
-    "force_unforce_finished" : True
+    "force_unforce_finished" : True,
+    "ignore_scheduler" : False
 }
 
 DEFAULT_STATES = {}
@@ -163,7 +164,7 @@ class Core(CorePluginBase):
         state = self.get_state()
         self.update_torrent()
 
-        if state == "Green":
+        if state == "Green" or self.config["ignore_scheduler"]:
             # This is Green (Normal) so we just make sure we've applied the
             # global defaults
             self.__apply_set_functions()
@@ -189,7 +190,7 @@ class Core(CorePluginBase):
             component.get("EventManager").emit(SchedulerEvent(self.state))
 
         # called after self.state is set
-        if self.config["force_use_individual"] and (state == 'Green' or state == 'Red'):
+        if self.config["force_use_individual"] and (state == 'Green' or state == 'Red' or self.config["ignore_scheduler"]):
             self.update_torrent()
 
         if timer:
@@ -281,7 +282,7 @@ class Core(CorePluginBase):
                 tstate = {'forced' : False, 'paused' : False }
                 self.torrent_states[torrent_id] = tstate
 
-            if self.state == 'Green' or self.state == 'Yellow':
+            if self.state == 'Green' or self.state == 'Yellow' or self.config["ignore_scheduler"]:
                 if tstate['paused']:
                     torrent.resume()
                     tstate['paused'] = False

--- a/myscheduler/data/myscheduler.js
+++ b/myscheduler/data/myscheduler.js
@@ -516,6 +516,15 @@ Deluge.ux.preferences.MySchedulerPage = Ext.extend(Ext.Panel, {
 
         this.schedule = this.form.add(new Deluge.ux.ScheduleSelector());
 
+        this.ignoreSettings = this.form.add({
+            xtype: 'fieldset',
+            border: false,
+            title: _('Scheduler Override'),
+            autoHeight: true,
+            defaultType: 'checkbox',
+            labelWidth: 80
+        });
+
         this.forcedSettings = this.form.add({
             xtype: 'fieldset',
             border: false,
@@ -523,6 +532,14 @@ Deluge.ux.preferences.MySchedulerPage = Ext.extend(Ext.Panel, {
             autoHeight: true,
             defaultType: 'checkbox',
             labelWidth: 80
+        });
+
+        this.chkIgnoreScheduler = this.ignoreSettings.add({
+            xtype: 'checkbox',
+            name: 'chkIgnoreScheduler',
+            height: 22,
+            hideLabel: true,
+            boxLabel: _('Ignore Scheduler')
         });
 
         this.chkIndividual = this.forcedSettings.add({
@@ -613,6 +630,7 @@ Deluge.ux.preferences.MySchedulerPage = Ext.extend(Ext.Panel, {
         config['low_active_up'] = this.activeSeeding.getValue();
         config["force_use_individual"] = this.chkIndividual.getValue();
         config["force_unforce_finished"] = this.chkUnforceFinished.getValue();
+        config["ignore_scheduler"] = this.chkIgnoreScheduler.getValue();
 
         deluge.client.myscheduler.set_config(config);
     },
@@ -637,6 +655,7 @@ Deluge.ux.preferences.MySchedulerPage = Ext.extend(Ext.Panel, {
                 this.activeSeeding.setValue(config['low_active_up']);
                 this.chkIndividual.setValue(config["force_use_individual"]);
                 this.chkUnforceFinished.setValue(config["force_unforce_finished"]);
+                this.chkIgnoreScheduler.setValue(config["ignore_scheduler"])
             },
             scope: this
         });

--- a/myscheduler/gtkui.py
+++ b/myscheduler/gtkui.py
@@ -203,6 +203,7 @@ class GtkUI(GtkPluginBase):
         config["button_state"] = self.scheduler_select.button_state
         config["force_use_individual"] = self.chkIndividual.get_active()
         config["force_unforce_finished"] = self.chkUnforceFinished.get_active()
+        config["ignore_scheduler"] = self.chkIgnoreScheduler.get_active()
         client.myscheduler.set_config(config)
 
     def on_show_prefs(self):
@@ -216,6 +217,7 @@ class GtkUI(GtkPluginBase):
             self.spin_active_up.set_value(config["low_active_up"])
             self.chkIndividual.set_active(config["force_use_individual"])
             self.chkUnforceFinished.set_active(config["force_unforce_finished"])
+            self.chkIgnoreScheduler.set_active(config["ignore_scheduler"])
 
 
         client.myscheduler.get_config().addCallback(on_get_config)
@@ -283,14 +285,25 @@ class GtkUI(GtkPluginBase):
 
         frame = gtk.Frame()
         label = gtk.Label()
-        label.set_markup(_("<b>Forced Settings</b>"))
+        label.set_markup(_("<b>Scheduler Override</b>"))
         frame.set_label_widget(label)
+        ignoreSchedulerVBox = gtk.VBox(False, 1)
+        self.chkIgnoreScheduler = gtk.CheckButton("Ignore Scheduler")     
+        ignoreSchedulerVBox.pack_start(self.chkIgnoreScheduler)   
+
+        frame.add(ignoreSchedulerVBox)
+        vbox.pack_start(frame, False, False)
             
+        frame = gtk.Frame()
+        label = gtk.Label()
+        label.set_markup(_("<b>Forced Settings</b>"))
+        frame.set_label_widget(label)    
         forcedvbox = gtk.VBox(False, 1)
         self.chkIndividual = gtk.CheckButton("Use Individual Scheduling")
         forcedvbox.pack_start(self.chkIndividual)
         self.chkUnforceFinished = gtk.CheckButton("Un-Force on Finished")
-        forcedvbox.pack_start(self.chkUnforceFinished)        
+        forcedvbox.pack_start(self.chkUnforceFinished)
+
 
         frame.add(forcedvbox)
         vbox.pack_start(frame, False, False)


### PR DESCRIPTION
On / Off tick box within the preferences that allows the user to override the schedule and use normal operation.